### PR TITLE
Default tester and its friends

### DIFF
--- a/impl/builder_with_skip_when_not_exists_test.go
+++ b/impl/builder_with_skip_when_not_exists_test.go
@@ -1,0 +1,38 @@
+package impl
+
+import (
+	"os"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/golang/mock/gomock"
+	"github.com/mniak/bench/internal/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_BuilderWithSkipWhenNotExist_WhenProgramExists_ShouldRunBuild(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	inputfile, err := os.CreateTemp("", "test_*.src")
+	require.NoError(t, err)
+	defer func() {
+		inputfile.Close()
+		os.Remove(inputfile.Name())
+	}()
+
+	inputpath := inputfile.Name()
+	outputpath := gofakeit.Sentence(5)
+
+	innerBuilder := mocks.NewMockBuilder(ctrl)
+	innerBuilder.EXPECT().
+		Build(inputpath).
+		Return(outputpath, nil)
+
+	sut := WrapBuilderWithSkipWhenNotExist(innerBuilder)
+
+	result, err := sut.Build(inputpath)
+	require.NoError(t, err)
+	assert.Equal(t, outputpath, result)
+}

--- a/impl/builder_with_skip_when_not_exists_test.go
+++ b/impl/builder_with_skip_when_not_exists_test.go
@@ -36,3 +36,17 @@ func Test_BuilderWithSkipWhenNotExist_WhenProgramExists_ShouldRunBuild(t *testin
 	require.NoError(t, err)
 	assert.Equal(t, outputpath, result)
 }
+
+func Test_BuilderWithSkipWhenNotExist_WhenProgramDoesNotExists_ShouldNotRunBuild(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	inputpath := gofakeit.Sentence(5)
+
+	innerBuilder := mocks.NewMockBuilder(ctrl)
+	sut := WrapBuilderWithSkipWhenNotExist(innerBuilder)
+
+	result, err := sut.Build(inputpath)
+	require.NoError(t, err)
+	assert.Equal(t, inputpath, result)
+}

--- a/impl/builder_with_skip_when_not_exists_test.go
+++ b/impl/builder_with_skip_when_not_exists_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_BuilderWithSkipWhenNotExist_WhenProgramExists_ShouldRunBuild(t *testing.T) {
+func Test_BuilderWithSkipWhenNotExist_WhenProgramExists_ShouldCallBuild(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -37,7 +37,7 @@ func Test_BuilderWithSkipWhenNotExist_WhenProgramExists_ShouldRunBuild(t *testin
 	assert.Equal(t, outputpath, result)
 }
 
-func Test_BuilderWithSkipWhenNotExist_WhenProgramDoesNotExists_ShouldNotRunBuild(t *testing.T) {
+func Test_BuilderWithSkipWhenNotExist_WhenProgramDoesNotExists_ShouldNotCallBuild(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 

--- a/impl/defaults.go
+++ b/impl/defaults.go
@@ -31,7 +31,12 @@ var DefaultProgramFinder = func() domain.FileFinder {
 }()
 
 var DefaultTester = WrapTesterWithFileFinder(
-	NewTester(),
+	WrapTesterWithBuilder(
+		NewTester(),
+		WrapBuilderWithSkipWhenNotExist(
+			NewBuilder(DefaultToolchainFinder),
+		),
+	),
 	DefaultProgramFinder,
 )
 

--- a/impl/defaults_test.go
+++ b/impl/defaults_test.go
@@ -39,5 +39,28 @@ func Test_DefaultBuilder_Composition(t *testing.T) {
 
 	require.IsType(t, &_BaseBuilder{}, bff.Builder)
 	bb := bff.Builder.(*_BaseBuilder)
+
 	require.Same(t, DefaultToolchainFinder, bb.toolchainFinder)
+}
+
+func Test_DefaultTester_Composition(t *testing.T) {
+	// DefaultTester =
+	//   decorator WithFullPath over
+	require.IsType(t, &_TesterWithFileFinder{}, DefaultTester)
+	tw_finder := DefaultTester.(*_TesterWithFileFinder)
+
+	//   decorator WithBuilder(TestBuilder) over
+	require.IsType(t, &_TesterWithBuilder{}, tw_finder.Tester)
+	tw_builder := tw_finder.Tester.(*_TesterWithBuilder)
+
+	//             BaseTester
+	require.IsType(t, &_BaseTester{}, tw_builder.Tester)
+
+	// TestBuilder =
+	//   decorator SkipIfDoesNotExist over
+	require.IsType(t, &_BuilderWithSkipWhenNotExist{}, tw_builder.builder)
+	bw_skip := tw_builder.builder.(*_BuilderWithSkipWhenNotExist)
+
+	//             BaseBuilder
+	require.IsType(t, &_BaseBuilder{}, bw_skip.Builder)
 }

--- a/impl/defaults_test.go
+++ b/impl/defaults_test.go
@@ -63,4 +63,7 @@ func Test_DefaultTester_Composition(t *testing.T) {
 
 	//             BaseBuilder
 	require.IsType(t, &_BaseBuilder{}, bw_skip.Builder)
+	base_builder := bw_skip.Builder.(*_BaseBuilder)
+
+	require.Equal(t, DefaultToolchainFinder, base_builder.toolchainFinder)
 }

--- a/impl/tester.go
+++ b/impl/tester.go
@@ -12,7 +12,7 @@ import (
 )
 
 type (
-	_Tester      struct{}
+	_BaseTester  struct{}
 	_StartedTest struct {
 		stdin  *bytes.Buffer
 		stdout *bytes.Buffer
@@ -44,10 +44,10 @@ func (s *_StartedTest) ExpectedOutput() string {
 }
 
 func NewTester() domain.Tester {
-	return new(_Tester)
+	return new(_BaseTester)
 }
 
-func (t *_Tester) Start(test domain.Test) (domain.StartedTest, error) {
+func (t *_BaseTester) Start(test domain.Test) (domain.StartedTest, error) {
 	var started _StartedTest
 	started.stdin = new(bytes.Buffer)
 	started.stdout = new(bytes.Buffer)
@@ -71,7 +71,7 @@ func (t *_Tester) Start(test domain.Test) (domain.StartedTest, error) {
 	return &started, err
 }
 
-func (t *_Tester) Wait(started domain.StartedTest) (result domain.TestResult, err error) {
+func (t *_BaseTester) Wait(started domain.StartedTest) (result domain.TestResult, err error) {
 	err = started.Cmd().Wait()
 	if err != nil {
 		err = errors.Wrap(err, "program wait failed")

--- a/impl/tester_test.go
+++ b/impl/tester_test.go
@@ -4,9 +4,7 @@ import (
 	"testing"
 
 	"github.com/brianvoe/gofakeit/v6"
-	"github.com/golang/mock/gomock"
 	"github.com/mniak/bench/domain"
-	"github.com/mniak/bench/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,84 +31,4 @@ func TestTest(t *testing.T) {
 
 func cloneTest(test domain.Test) domain.Test {
 	return test
-}
-
-func TestWrapWithProgramFinder(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	var faketest domain.Test
-	var fakestarted domain.StartedTest
-	var fakeresult domain.TestResult
-
-	require.NoError(t, gofakeit.Struct(&faketest))
-	require.NoError(t, gofakeit.Struct(&fakestarted))
-	require.NoError(t, gofakeit.Struct(&fakeresult))
-
-	fakeprogram := gofakeit.Sentence(5)
-	faketestWithFakeprogram := cloneTest(faketest)
-	faketestWithFakeprogram.Program = fakeprogram
-
-	tester := mocks.NewMockTester(ctrl)
-	tester.EXPECT().
-		Start(faketestWithFakeprogram).
-		Return(fakestarted, nil)
-	tester.EXPECT().
-		Wait(fakestarted).
-		Return(fakeresult, nil)
-
-	programFinder := mocks.NewMockFileFinder(ctrl)
-	programFinder.EXPECT().
-		Find(faketest.Program).
-		Return(fakeprogram, nil)
-
-	sut := WrapTesterWithFileFinder(tester, programFinder)
-
-	started, err := sut.Start(faketest)
-	assert.NoError(t, err)
-
-	result, err := sut.Wait(started)
-	assert.NoError(t, err)
-
-	assert.Equal(t, fakeresult, result)
-}
-
-func TestWrapWithBuilder_WhenSourceFileExists_Should(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	var faketest domain.Test
-	var fakestarted domain.StartedTest
-	var fakeresult domain.TestResult
-
-	require.NoError(t, gofakeit.Struct(&faketest))
-	require.NoError(t, gofakeit.Struct(&fakestarted))
-	require.NoError(t, gofakeit.Struct(&fakeresult))
-
-	fakeprogram := gofakeit.Word()
-	faketestWithFakeprogram := cloneTest(faketest)
-	faketestWithFakeprogram.Program = fakeprogram
-
-	tester := mocks.NewMockTester(ctrl)
-	tester.EXPECT().
-		Start(faketestWithFakeprogram).
-		Return(fakestarted, nil)
-	tester.EXPECT().
-		Wait(fakestarted).
-		Return(fakeresult, nil)
-
-	builder := mocks.NewMockBuilder(ctrl)
-	builder.EXPECT().
-		Build(faketest.Program).
-		Return(fakeprogram, nil)
-
-	sut := WrapTesterWithBuilder(tester, builder)
-
-	started, err := sut.Start(faketest)
-	assert.NoError(t, err)
-
-	result, err := sut.Wait(started)
-	assert.NoError(t, err)
-
-	assert.Equal(t, fakeresult, result)
 }

--- a/impl/tester_with_builder_test.go
+++ b/impl/tester_with_builder_test.go
@@ -1,0 +1,59 @@
+package impl
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/golang/mock/gomock"
+	"github.com/mniak/bench/domain"
+	"github.com/mniak/bench/internal/mocks"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_TesterWithBuilder_Start_ShouldCallBuilder(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var fakeTest domain.Test
+	gofakeit.Struct(&fakeTest)
+	var fakeStarted domain.StartedTest
+	gofakeit.Struct(&fakeStarted)
+
+	fakeProgram := gofakeit.Sentence(5)
+	fakeTestWithFakeProgram := cloneTest(fakeTest)
+	fakeTestWithFakeProgram.Program = fakeProgram
+
+	builder := mocks.NewMockBuilder(ctrl)
+	builder.EXPECT().Build(fakeTest.Program).Return(fakeProgram, nil)
+
+	tester := mocks.NewMockTester(ctrl)
+	tester.EXPECT().Start(fakeTestWithFakeProgram).Return(fakeStarted, nil)
+
+	sut := WrapTesterWithBuilder(tester, builder)
+	result, err := sut.Start(fakeTest)
+	require.NoError(t, err)
+	assert.Equal(t, fakeStarted, result)
+}
+
+func Test_TesterWithBuilder_Wait_ShouldBypass(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var fakeStarted domain.StartedTest
+	gofakeit.Struct(&fakeStarted)
+	var fakeResult domain.TestResult
+	gofakeit.Struct(&fakeResult)
+	fakeError := errors.New(gofakeit.Sentence(5))
+
+	tester := mocks.NewMockTester(ctrl)
+	builder := mocks.NewMockBuilder(ctrl)
+
+	tester.EXPECT().Wait(fakeStarted).Return(fakeResult, fakeError)
+
+	sut := WrapTesterWithBuilder(tester, builder)
+	result, err := sut.Wait(fakeStarted)
+	require.Equal(t, fakeError, err)
+	assert.Equal(t, fakeResult, result)
+}

--- a/impl/tester_with_file_finder_test.go
+++ b/impl/tester_with_file_finder_test.go
@@ -1,0 +1,92 @@
+package impl
+
+import (
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/golang/mock/gomock"
+	"github.com/mniak/bench/domain"
+	"github.com/mniak/bench/internal/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Tester_WithFileFinder(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var faketest domain.Test
+	var fakestarted domain.StartedTest
+	var fakeresult domain.TestResult
+
+	require.NoError(t, gofakeit.Struct(&faketest))
+	require.NoError(t, gofakeit.Struct(&fakestarted))
+	require.NoError(t, gofakeit.Struct(&fakeresult))
+
+	fakeprogram := gofakeit.Sentence(5)
+	faketestWithFakeProgram := cloneTest(faketest)
+	faketestWithFakeProgram.Program = fakeprogram
+
+	innerTester := mocks.NewMockTester(ctrl)
+	innerTester.EXPECT().
+		Start(faketestWithFakeProgram).
+		Return(fakestarted, nil)
+	innerTester.EXPECT().
+		Wait(fakestarted).
+		Return(fakeresult, nil)
+
+	fileFinder := mocks.NewMockFileFinder(ctrl)
+	fileFinder.EXPECT().
+		Find(faketest.Program).
+		Return(fakeprogram, nil)
+
+	sut := WrapTesterWithFileFinder(innerTester, fileFinder)
+
+	started, err := sut.Start(faketest)
+	assert.NoError(t, err)
+
+	result, err := sut.Wait(started)
+	assert.NoError(t, err)
+
+	assert.Equal(t, fakeresult, result)
+}
+
+func TestWrapWithBuilder_WhenSourceFileExists_Should(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var faketest domain.Test
+	var fakestarted domain.StartedTest
+	var fakeresult domain.TestResult
+
+	require.NoError(t, gofakeit.Struct(&faketest))
+	require.NoError(t, gofakeit.Struct(&fakestarted))
+	require.NoError(t, gofakeit.Struct(&fakeresult))
+
+	fakeprogram := gofakeit.Word()
+	faketestWithFakeprogram := cloneTest(faketest)
+	faketestWithFakeprogram.Program = fakeprogram
+
+	tester := mocks.NewMockTester(ctrl)
+	tester.EXPECT().
+		Start(faketestWithFakeprogram).
+		Return(fakestarted, nil)
+	tester.EXPECT().
+		Wait(fakestarted).
+		Return(fakeresult, nil)
+
+	builder := mocks.NewMockBuilder(ctrl)
+	builder.EXPECT().
+		Build(faketest.Program).
+		Return(fakeprogram, nil)
+
+	sut := WrapTesterWithBuilder(tester, builder)
+
+	started, err := sut.Start(faketest)
+	assert.NoError(t, err)
+
+	result, err := sut.Wait(started)
+	assert.NoError(t, err)
+
+	assert.Equal(t, fakeresult, result)
+}


### PR DESCRIPTION
### `DefaultTester`
- [x]  Add test to validate the composition

```
TestBuilder = 
  decorator SkipIfDoesNotExist over
            BaseBuilder

DefaultTester =
  decorator WithFullPath over
  decorator WithBuilder(TestBuilder) over
            BaseTester
```
#### `BaseTester`
- This is working well. I will not describe it again.

#### Decorator `SkipIfDoesNotExist` (Builder)
- [x] If `program` exists, run builder build
- [x] If `program` does not exist, do nothing. 

#### Decorator `WithFullPath` (Builder)
- [x] Pass `program` to file finder, then take the result and put in `program`

#### Decorator `WithBuilder`
- [x] Pass `program` to the builder build, take the result and put in `program`
