### PR TITLE
Use full path for output file on MSBuild

### DIFF
--- a/toolchain/cpp_windows.go
+++ b/toolchain/cpp_windows.go
@@ -28,6 +28,11 @@ func (tc *_MSVCToolchain) Build(inputpath, outputpath string) error {
 		return err
 	}
 
+	outputpath, err = filepath.Abs(outputpath)
+	if err != nil {
+		return err
+	}
+
 	cmd := exec.Command(tc.clpath, main, "/link", "/out:"+outputpath)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Closes #33